### PR TITLE
Add a podspec file for cocoapods

### DIFF
--- a/RRuleSwift.podspec
+++ b/RRuleSwift.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name             = 'RRuleSwift'
+  s.version          = '0.1.1'
+  s.summary          = 'Swift rrule library for working with recurrence rules of calendar dates.'
+  s.homepage         = 'https://github.com/teambition/RRuleSwift'
+  s.license          = { :type => 'MIT', :file => 'LICENSE.md' }
+  s.author           = { 'Teambition' => 'dev@teambition.com' }
+  s.source           = { :git => 'https://github.com/teambition/RRuleSwift.git', :tag => s.version.to_s }
+  s.ios.deployment_target = '8.0'
+  s.source_files = 'Sources/**/*'
+end


### PR DESCRIPTION
Hello. I created a podspec file for cocoapods. If needed you can add/edit an additional information to the file (Or I can do it :)). For publishing pod you need to execute `pod trunk push RRuleSwift.podspec` from project dir.