### PR TITLE
Fixed the timezone related freeze

### DIFF
--- a/RRuleSwift.xcodeproj/project.pbxproj
+++ b/RRuleSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6BD694AB20D9C6F40008B4C6 /* DateFormatter+RRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD694AA20D9C6F40008B4C6 /* DateFormatter+RRule.swift */; };
 		EB48D1611D641D45001EE872 /* EKWeekday+RRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB48D1511D641D45001EE872 /* EKWeekday+RRule.swift */; };
 		EB48D1621D641D45001EE872 /* EKWeekday+RRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB48D1511D641D45001EE872 /* EKWeekday+RRule.swift */; };
 		EB48D1631D641D45001EE872 /* ExclusionDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB48D1521D641D45001EE872 /* ExclusionDate.swift */; };
@@ -30,6 +31,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6BD694AA20D9C6F40008B4C6 /* DateFormatter+RRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+RRule.swift"; sourceTree = "<group>"; };
 		D31B13971CA8E02E00D0B863 /* RRuleSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RRuleSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB48D1371D641AD6001EE872 /* RRuleSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RRuleSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB48D1511D641D45001EE872 /* EKWeekday+RRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EKWeekday+RRule.swift"; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				EB48D1551D641D45001EE872 /* JavaScriptBridge.swift */,
 				EB48D1511D641D45001EE872 /* EKWeekday+RRule.swift */,
 				EB48D1591D641D45001EE872 /* NSDate+Comparison.swift */,
+				6BD694AA20D9C6F40008B4C6 /* DateFormatter+RRule.swift */,
 				EB48D1561D641D45001EE872 /* lib */,
 				EB48D15D1D641D45001EE872 /* Supporting Files */,
 			);
@@ -248,6 +251,7 @@
 				EB48D1691D641D45001EE872 /* JavaScriptBridge.swift in Sources */,
 				EB48D16F1D641D45001EE872 /* NSDate+Comparison.swift in Sources */,
 				EB48D1751D641D45001EE872 /* RRule.swift in Sources */,
+				6BD694AB20D9C6F40008B4C6 /* DateFormatter+RRule.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/DateFormatter+RRule.swift
+++ b/Sources/DateFormatter+RRule.swift
@@ -1,0 +1,27 @@
+//
+//  DateFormatter+RRule.swift
+//  RRuleSwift-iOS
+//
+//  Created by Sunny Chan on 6/19/18.
+//  Copyright © 2018 Teambition. All rights reserved.
+//
+
+import Foundation
+
+extension DateFormatter {
+	convenience init(_ dateFormat: String, _ timeZone: TimeZone? = nil, _ safely: Bool = true) {
+		self.init()
+		self.dateFormat = dateFormat
+		
+		if timeZone == nil {
+			self.timeZone = TimeZone(secondsFromGMT: 0)
+		}
+		
+		if safely {
+			// NOTE: AM/PM on 12/24 hour switch is broken on some locale.
+			// https://stackoverflow.com/a/6735644
+			// https://github.com/teambition/RRuleSwift/issues/12
+			self.locale = Locale(identifier: "en_US_POSIX")
+		}
+	}
+}

--- a/Sources/RRule.swift
+++ b/Sources/RRule.swift
@@ -11,22 +11,17 @@ import EventKit
 
 public struct RRule {
     public static let dateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        dateFormatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+		let dateFormatter = DateFormatter("yyyyMMdd'T'HHmmss'Z'")
         return dateFormatter
     }()
+	
     public static let ymdDateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        dateFormatter.dateFormat = "yyyyMMdd"
+		let dateFormatter = DateFormatter("yyyyMMdd")
         return dateFormatter
     }()
 
     internal static let ISO8601DateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        let dateFormatter = DateFormatter("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
         return dateFormatter
     }()
 


### PR DESCRIPTION
**Problem:** The DateFormatter has a feature that will add the AM/PM to any formatted string (even if the format doesn't include AM/PM) if the user sets his/her phone to a 24-hour region, like Great Britain, and then toggle on the 24-Hour Time switch, and then toggle off. 

**Solution:** Use a region that is not broken, for example the US region in a safe init method. 

Reference: https://stackoverflow.com/questions/6613110/what-is-the-best-way-to-deal-with-the-nsdateformatter-locale-feechur