### PR TITLE
static JSContext issue with multiple threads

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "RRuleSwift-iOS",
-            dependencies: [],
+            dependencies: [] //,
 //            path: "RRuleSwift-iOS"
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "RRuleSwift",
+    platforms: [
+        .iOS(.v10),
+        .macOS(.v10_12),
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "RRuleSwift-iOS",
+            targets: ["RRuleSwift-iOS"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "RRuleSwift-iOS",
+            dependencies: [],
+//            path: "RRuleSwift-iOS"
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "RRuleSwift-iOS",
+            name: "RRuleSwift",
             targets: ["RRuleSwift-iOS"]),
     ],
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "RRuleSwift-iOS",
-            dependencies: [] //,
-//            path: "RRuleSwift-iOS"
+            dependencies: [],
+            path: ""
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .target(
             name: "RRuleSwift-iOS",
             dependencies: [],
-            path: ""
+            path: "Sources"
         ),
     ]
 )

--- a/RRuleSwiftExample/RRuleExampleViewController.swift
+++ b/RRuleSwiftExample/RRuleExampleViewController.swift
@@ -61,7 +61,6 @@ class RRuleExampleViewController: UIViewController {
         super.viewDidLoad()
         setupUI()
         testRRuleIterator()
-        testRRuleIteratorMultipleThreads()
     }
 
     fileprivate func setupUI() {
@@ -76,14 +75,14 @@ class RRuleExampleViewController: UIViewController {
     
     fileprivate func testRRuleIteratorMultipleThreads() {
         DispatchQueue.global(qos: .background).async {
-            for n in 1...1000
+            for n in 1...100
             {
                 self.testRRuleIterator(n)
             }
         }
 
         DispatchQueue.global(qos: .background).async {
-            for n in 1...1000
+            for n in 1...100
             {
                 self.testRRuleIterator(-n)
             }
@@ -91,6 +90,40 @@ class RRuleExampleViewController: UIViewController {
     }
     
     fileprivate func testRRuleIterator(_ n : Int) {
+        let ruleFormat = "RRULE:FREQ=WEEKLY;DTSTART=%@%@01T014500Z;INTERVAL=1;UNTIL=%@%@01T014500Z"
+        let calendar = NSCalendar.current
+        var startDateComponents = DateComponents()
+        startDateComponents.month = n;
+        let startDate = calendar.date(byAdding: startDateComponents, to: Date())
+        startDateComponents = calendar.dateComponents([.year, .month], from: startDate!)
+        
+        var endDateComponents = DateComponents()
+        endDateComponents.month = 6
+        let endDate = calendar.date(byAdding: endDateComponents, to: startDate!)
+        endDateComponents = calendar.dateComponents([.year, .month], from: endDate!)
+
+        var startDateMonth = String(startDateComponents.month!)
+        if (startDateComponents.month! < 10)
+        {
+            startDateMonth = "0".appending(startDateMonth)
+        }
+        var endDateMonth = String(endDateComponents.month!)
+        if (endDateComponents.month! < 10)
+        {
+            endDateMonth = "0".appending(endDateMonth)
+        }
+
+        let rruleString = String(format: ruleFormat, String(startDateComponents.year!), startDateMonth, String(endDateComponents.year!), endDateMonth )
+        
+        print ("rruleString: ", rruleString)
+        var rule = RecurrenceRule(rruleString: rruleString)!
+        
+        let occurrences = rule.allOccurrences()
+        print ("occurrences for rrule: ", rruleString, ", count:", occurrences.count, ", first:", occurrences.first)
+        if !calendar.isDate(startDate!, equalTo: occurrences.first!, toGranularity: .day)
+        {
+            print("dates mismatch, got: ", occurrences.first, ", expected: ", startDate)
+        }
     }
     
     fileprivate func testRRuleIterator() {

--- a/RRuleSwiftExample/RRuleExampleViewController.swift
+++ b/RRuleSwiftExample/RRuleExampleViewController.swift
@@ -61,6 +61,7 @@ class RRuleExampleViewController: UIViewController {
         super.viewDidLoad()
         setupUI()
         testRRuleIterator()
+        testRRuleIteratorMultipleThreads()
     }
 
     fileprivate func setupUI() {
@@ -72,7 +73,26 @@ class RRuleExampleViewController: UIViewController {
         textView.delegate = self
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reset", style: .plain, target: self, action: #selector(resetButtonTapped(_:)))
     }
+    
+    fileprivate func testRRuleIteratorMultipleThreads() {
+        DispatchQueue.global(qos: .background).async {
+            for n in 1...1000
+            {
+                self.testRRuleIterator(n)
+            }
+        }
 
+        DispatchQueue.global(qos: .background).async {
+            for n in 1...1000
+            {
+                self.testRRuleIterator(-n)
+            }
+        }
+    }
+    
+    fileprivate func testRRuleIterator(_ n : Int) {
+    }
+    
     fileprivate func testRRuleIterator() {
         let dateFormatter: DateFormatter = {
             let dateFormatter = DateFormatter()

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -31,8 +31,7 @@ public extension RecurrenceRule {
         }
 
         let ruleJSONString = toJSONString(endless: endlessRecurrenceCount)
-        let _ = Iterator.rruleContext?.evaluateScript("var rule = new RRule({ \(ruleJSONString) })")
-        guard let allOccurrences = Iterator.rruleContext?.evaluateScript("rule.all()").toArray() as? [Date] else {
+        guard let allOccurrences = Iterator.rruleContext?.evaluateScript("new RRule({ \(ruleJSONString) }).all()").toArray() as? [Date] else {
             return []
         }
 
@@ -67,8 +66,7 @@ public extension RecurrenceRule {
         let untilDateJSON = RRule.ISO8601DateFormatter.string(from: untilDate)
 
         let ruleJSONString = toJSONString(endless: endlessRecurrenceCount)
-        let _ = Iterator.rruleContext?.evaluateScript("var rule = new RRule({ \(ruleJSONString) })")
-        guard let betweenOccurrences = Iterator.rruleContext?.evaluateScript("rule.between(new Date('\(beginDateJSON)'), new Date('\(untilDateJSON)'))").toArray() as? [Date] else {
+        guard let betweenOccurrences = Iterator.rruleContext?.evaluateScript("new RRule({ \(ruleJSONString) }).between(new Date('\(beginDateJSON)'), new Date('\(untilDateJSON)'))").toArray() as? [Date] else {
             return []
         }
 


### PR DESCRIPTION
It seems that static JSContext (Iterator.rruleContext) is causing problems when there are calculations on different threads. It happens, when in some (not so rare) cases two `context?.evaluateScript("var rule = new RRule({ \(ruleJSONString) })")` is being called one after another and only then two dates calculations
```
        guard let allOccurrences = context?.evaluateScript("rule.all()").toArray() as? [Date] else {
            return []
        }
```
also one after another. And in such case the second `new RRule({ \(ruleJSONString) })` overwrites first RRule's properties in static JSContext and first calculation uses wrong parameters. 
One way to avoid this issue would be reduce evaluateScript calls (create a rule and evaluate it in one evaluateScript call. I couldn't reproduce this issue after such modification):
`        guard let allOccurrences = Iterator.rruleContext?.evaluateScript("new RRule({ \(ruleJSONString) }).all()").toArray() as? [Date] else {`
instead of
```
        let _ = Iterator.rruleContext?.evaluateScript("var rule = new RRule({ \(ruleJSONString) })")
         guard let allOccurrences = Iterator.rruleContext?.evaluateScript("rule.all()").toArray() as? [Date] else {
```
I also implemented a test, that could help quite easily reproduce the issue: you can launch Sample app and make `testRRuleIteratorMultipleThreads()` call in the `viewDidLoad()`. There are 2 background thread that generates rrule and checks the returned dates. If everything worked as expected, then there would be no logs in console similar to `print("dates mismatch, got: ", occurrences.first, ", expected: ", startDate)` - first date returned by rrule's Iterator.rruleContext?.evaluateScript should be equal to its startDate. But in some 5th-10th iteration one thread overrides other's rrule parameters and wrong parameters are being used. I hope I made myself clear.